### PR TITLE
Add user-agent support for request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 mediacheck
+launch.json
+go.mod
+go.sum

--- a/mediacheck.go
+++ b/mediacheck.go
@@ -121,7 +121,7 @@ func main() {
 	}
 }
 
-func NewRequestWithUserAgent(method, url, userAgent string) (*http.Request, error) {
+func newRequestWithUserAgent(method, url, userAgent string) (*http.Request, error) {
 	req, err := http.NewRequest(method, url, nil)
 	if err != nil {
 		return nil, err
@@ -144,7 +144,7 @@ func fetchURL(ctx context.Context, u *url.URL) (string, []byte, error) {
 		r   *http.Response
 		err error
 	}, 1)
-	req, err := NewRequestWithUserAgent("GET", u.String(), "Mozilla/5.0 (X11; Linux i686; rv:10.0) Gecko/20100101 Firefox/10.0")
+	req, err := newRequestWithUserAgent("GET", u.String(), "Mozilla/5.0 (X11; Linux i686; rv:10.0) Gecko/20100101 Firefox/10.0")
 	if err != nil {
 		return "", nil, err
 	}
@@ -266,7 +266,7 @@ func checkMedia(ctx context.Context, u *url.URL) error {
 		err error
 	}, 1)
 
-	req, err := NewRequestWithUserAgent("GET", u.String(), "Mozilla/5.0 (X11; Linux i686; rv:10.0) Gecko/20100101 Firefox/10.0")
+	req, err := newRequestWithUserAgent("GET", u.String(), "Mozilla/5.0 (X11; Linux i686; rv:10.0) Gecko/20100101 Firefox/10.0")
 	if err != nil {
 		return err
 	}

--- a/mediacheck.go
+++ b/mediacheck.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"golang.org/x/net/html"
 )
@@ -121,6 +121,17 @@ func main() {
 	}
 }
 
+func NewRequestWithUserAgent(method, url, userAgent string) (*http.Request, error) {
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("User-Agent", userAgent)
+
+	return req, nil
+}
+
 func fetchURL(ctx context.Context, u *url.URL) (string, []byte, error) {
 	tr := &http.Transport{}
 	if !verifySSL {
@@ -133,7 +144,7 @@ func fetchURL(ctx context.Context, u *url.URL) (string, []byte, error) {
 		r   *http.Response
 		err error
 	}, 1)
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := NewRequestWithUserAgent("GET", u.String(), "Mozilla/5.0 (X11; Linux i686; rv:10.0) Gecko/20100101 Firefox/10.0")
 	if err != nil {
 		return "", nil, err
 	}
@@ -254,7 +265,8 @@ func checkMedia(ctx context.Context, u *url.URL) error {
 		r   *http.Response
 		err error
 	}, 1)
-	req, err := http.NewRequest("GET", u.String(), nil)
+
+	req, err := NewRequestWithUserAgent("GET", u.String(), "Mozilla/5.0 (X11; Linux i686; rv:10.0) Gecko/20100101 Firefox/10.0")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Some sites rejects requests without user-agent which will fail our checks going into a redirect loop.  This commit is to add an arbitrary user-agent so that the requests goes through.

