### PR TITLE
Update makefile to statically link go executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ROOT_DIR:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
 mediacheck: *.go
-	go build .
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' .
 
 build:
 	docker run --rm -v $(ROOT_DIR):/src -v /var/run/docker.sock:/var/run/docker.sock centurylink/golang-builder thraxil/mediacheck


### PR DESCRIPTION
I think we need to build a statically-linked executable, not dynamic.

I took these params from hound's build step:
https://github.com/ccnmtl/hound/blob/master/Makefile#L6